### PR TITLE
Add device monitoring (#6)

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -44,7 +44,9 @@ gtkterm_SOURCES = \
     gresource.c \
     gresource.h \
     gicon.c \
-    gicon.h
+	gicon.h \
+	device_monitor.c \
+	device_monitor.h
 
 BUILT_SOURCES = \
     gresource.c \
@@ -58,3 +60,4 @@ CLEANFILES = $(BUILT_SOURCES) *~
 
 
 AM_CPPFLAGS = -DLOCALEDIR=\""$(localedir)"\"
+AM_LDFLAGS = -ludev

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -105,7 +105,7 @@ am_gtkterm_OBJECTS = term_config.$(OBJEXT) files.$(OBJEXT) \
 	gtkterm.$(OBJEXT) serial.$(OBJEXT) interface.$(OBJEXT) \
 	cmdline.$(OBJEXT) parsecfg.$(OBJEXT) buffer.$(OBJEXT) \
 	macros.$(OBJEXT) i18n.$(OBJEXT) logging.$(OBJEXT) \
-	gresource.$(OBJEXT) gicon.$(OBJEXT)
+	gresource.$(OBJEXT) gicon.$(OBJEXT) device_monitor.$(OBJEXT)
 gtkterm_OBJECTS = $(am_gtkterm_OBJECTS)
 am__DEPENDENCIES_1 =
 gtkterm_DEPENDENCIES = $(am__DEPENDENCIES_1) $(am__DEPENDENCIES_1)
@@ -309,7 +309,9 @@ gtkterm_SOURCES = \
     gresource.c \
     gresource.h \
     gicon.c \
-    gicon.h
+   	gicon.h \
+	device_monitor.c \
+	device_monitor.h
 
 BUILT_SOURCES = \
     gresource.c \
@@ -320,6 +322,7 @@ BUILT_SOURCES = \
 gtkterm_LDADD = $(gtk_LIBS) $(vte_LIBS)
 CLEANFILES = $(BUILT_SOURCES) *~
 AM_CPPFLAGS = -DLOCALEDIR=\""$(localedir)"\"
+AM_LDFLAGS = -ludev
 all: $(BUILT_SOURCES)
 	$(MAKE) $(AM_MAKEFLAGS) all-am
 
@@ -409,6 +412,7 @@ distclean-compile:
 
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/buffer.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/cmdline.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/device_monitor.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/files.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/gicon.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/gresource.Po@am__quote@

--- a/src/device_monitor.c
+++ b/src/device_monitor.c
@@ -1,3 +1,17 @@
+/***********************************************************************/
+/* device_mintor.h                                                     */
+/* ---------                                                           */
+/*           GTKTerm Software                                          */
+/*                      (c) Julien Schmitt                             */
+/*                                                                     */
+/* ------------------------------------------------------------------- */
+/*                                                                     */
+/*   Purpose                                                           */
+/*      Monitor device to autoreconnect                                */
+/*   Written by Kevin Picot - picotk27@gmail.com                       */
+/*                                                                     */
+/***********************************************************************/
+
 #include <device_monitor.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/device_monitor.c
+++ b/src/device_monitor.c
@@ -1,0 +1,84 @@
+#include <device_monitor.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <unistd.h>
+#include <libudev.h>
+#include <locale.h>
+#include <string.h>
+#include <gtk/gtk.h>
+#include <glib.h>
+#include <serial.h>
+#include <interface.h>
+#include <glib/gprintf.h>
+#include <term_config.h>
+
+extern struct configuration_port config;
+
+static inline void device_monitor_status(const bool connected) {
+
+    gchar *message;
+
+    if( connected )
+        Config_port();
+    else
+        Close_port();
+
+    message = get_port_string();
+
+    Set_status_message(message);
+    Set_window_title(message);
+    g_free(message);
+}
+
+static inline void device_monitor_handle(struct udev_device *dev) {
+
+    if( strcmp(udev_device_get_action(dev), "remove") == 0 ) {
+        device_monitor_status(false);
+    } else if( strcmp(udev_device_get_action(dev), "add") == 0 ) {
+        device_monitor_status(true);
+    }
+}
+
+static gpointer device_monitor_thread(gpointer data) {
+
+    struct udev *udev;
+    struct udev_monitor *mon;
+
+    udev = udev_new();
+    mon = udev_monitor_new_from_netlink(udev, "udev");
+
+    if( mon == NULL ) {
+        g_printf("%s:%u udev error\n", __func__, __LINE__);
+        return NULL;
+    }
+
+    udev_monitor_enable_receiving(mon);
+
+    while (1) {
+
+        struct udev_device *dev;
+
+        dev = udev_monitor_receive_device(mon);
+
+        if (dev) {
+
+            const char *n = udev_device_get_devnode(dev);
+            const gchar *name = config.port;
+
+            if( n != NULL )
+                if( strcmp(n, name) == 0 )
+                    device_monitor_handle(dev);
+
+            udev_device_unref(dev);
+        }
+        usleep(250*1000);
+    }
+}
+
+extern void device_monitor_start(void) {
+
+    /* Create gtk thread */
+    g_thread_new("dev_mon_th", device_monitor_thread, NULL);
+}

--- a/src/device_monitor.h
+++ b/src/device_monitor.h
@@ -1,0 +1,6 @@
+#ifndef DEV_MON
+#define DEV_MON
+
+extern void device_monitor_start(void);
+
+#endif

--- a/src/device_monitor.h
+++ b/src/device_monitor.h
@@ -1,5 +1,19 @@
-#ifndef DEV_MON
-#define DEV_MON
+/***********************************************************************/
+/* device_mintor.h                                                     */
+/* ---------                                                           */
+/*           GTKTerm Software                                          */
+/*                      (c) Julien Schmitt                             */
+/*                                                                     */
+/* ------------------------------------------------------------------- */
+/*                                                                     */
+/*   Purpose                                                           */
+/*      Monitor device to autoreconnect                                */
+/*   Written by Kevin Picot - picotk27@gmail.com                       */
+/*                                                                     */
+/***********************************************************************/
+
+#ifndef DEV_MON_H_
+#define DEV_MON_H_
 
 extern void device_monitor_start(void);
 


### PR DESCRIPTION
Hi there,

I am using gtkterm for embedded development, and I was only missing autoreconnect feature (saw it in issue #6 too), so here is a suggested solution.

Known limitation: 
Using thread involves concurrent access to `struct configuration_port config`. So in theory, as it is global variable it is pretty hard work to add mutex. In practise probabilty is relatively low.

It would be great to get your feedback on it ;-)