### PR TITLE
Udev build fix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -16,6 +16,7 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 PKG_CHECK_MODULES([gtk], [gtk+-3.0 >= 3.12.0])
 PKG_CHECK_MODULES([vte], [vte-2.91 >= 0.40.0])
+PKG_CHECK_MODULES([udev], [libudev >= 232])
 
 if test "$CC" = "gcc" ; then
   GNUCFLAGS="-Wall -fno-omit-frame-pointer -fno-strict-aliasing -O2"
@@ -29,7 +30,7 @@ if test x$GLIB_COMPILE_RESOURCES = xno; then
 fi
 
 # Check for required include files
-AC_CHECK_HEADERS([linux/serial.h libudev.h], [], [AC_MSG_ERROR([Couldn't find or include header file.])])
+AC_CHECK_HEADERS([linux/serial.h], [], [AC_MSG_ERROR([Couldn't find or include header file.])])
 
 AC_CONFIG_FILES([Makefile src/Makefile po/Makefile.in])
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,6 +1,6 @@
 # GtkTerm src/Makefile.am
 
-AM_CFLAGS = $(gtk_CFLAGS) $(vte_CFLAGS)
+AM_CFLAGS = $(gtk_CFLAGS) $(vte_CFLAGS) $(udev_CFLAGS)
 
 bin_PROGRAMS = gtkterm
 
@@ -54,10 +54,9 @@ BUILT_SOURCES = \
     gicon.c \
     gicon.h
 
-gtkterm_LDADD = $(gtk_LIBS) $(vte_LIBS)
+gtkterm_LDADD = $(gtk_LIBS) $(vte_LIBS) $(udev_LIBS)
 
 CLEANFILES = $(BUILT_SOURCES) *~
 
 
 AM_CPPFLAGS = -DLOCALEDIR=\""$(localedir)"\"
-AM_LDFLAGS = -ludev


### PR DESCRIPTION
I get a link error. Using AM_LDADD does not work with all versions of Autotools. I think it is cleaner to use pkg-config for udev