### PR TITLE
Use gudev instead of plain udev

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -8,7 +8,7 @@ project(
 # Find dependencies
 gtk_deps = dependency('gtk+-3.0', version : '>= 3.0.0')
 vte_deps = dependency('vte-2.91', version : '>= 0.28.0')
-udev_deps = dependency('libudev', version: '>= 229')
+gudev_deps = dependency('gudev-1.0', version: '>= 230')
 
 # Find install paths
 prefix = get_option('prefix')

--- a/src/device_monitor.c
+++ b/src/device_monitor.c
@@ -27,10 +27,9 @@
 #include <interface.h>
 #include <glib/gprintf.h>
 #include <term_config.h>
+#include <gudev/gudev.h>
 
 #include "interface.h"
-
-#include <gudev/gudev.h>
 
 extern struct configuration_port config;
 
@@ -73,8 +72,18 @@ extern void device_monitor_start(void) {
 
     const gchar *const subsystems[] = {NULL, NULL};
 
+    /* Initial check */
     GUdevClient *udev_client = g_udev_client_new(subsystems);
 
+    if( g_udev_client_query_by_device_file(udev_client, config.port) == NULL ) {
+        g_printf("Device %s not detected\n", config.port);
+        device_monitor_status(false);
+    } else {
+        g_printf("Device %s detected\n", config.port);
+        device_monitor_status(true);
+    }
+
+    /* Monitor device */
     g_signal_connect(G_OBJECT(udev_client), "uevent",
             G_CALLBACK(event_udev), NULL);
 }

--- a/src/meson.build
+++ b/src/meson.build
@@ -33,8 +33,8 @@ executable(
 	dependencies : [
 		gtk_deps,
 		vte_deps,
-		udev_deps,
-		config
+        config,
+        gudev_deps
 	],
 	install : true
 )


### PR DESCRIPTION
- Use gudev for device monitoring as suggested in issue #22
- Update status of port at device monitoring start