### PR TITLE
FIX set variable `virt_col_pos` to zero in buffer clean function

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -38,6 +38,9 @@ static unsigned int pointer;
 static int cr_received = 0;
 char overlapped;
 
+extern guint virt_col_pos;
+
+
 void (*write_func)(const char *, unsigned int) = NULL;
 void (*clear_func)(void) = NULL;
 
@@ -232,6 +235,8 @@ void clear_buffer(void)
 	current_buffer = buffer;
 	pointer = 0;
 	cr_received = 0;
+
+	virt_col_pos = 0;
 }
 
 void set_clear_func(void (*func)(void))

--- a/src/interface.c
+++ b/src/interface.c
@@ -110,7 +110,7 @@ static gint bytes_per_line = 16;
 static gchar blank_data[128];
 static guint total_bytes;
 static gboolean show_index = FALSE;
-static guint virt_col_pos = 0;
+guint virt_col_pos = 0;
 
 /* Local functions prototype */
 void signals_send_break_callback(GtkAction *action, gpointer data);


### PR DESCRIPTION
FIX set variable `virt_col_pos` to zero in buffer clean function for correct explode data to columns in hexadecimal mode.