### PR TITLE
Add missing #include directives, for C99 compatibility

### DIFF
--- a/src/interface.c
+++ b/src/interface.c
@@ -79,6 +79,7 @@
 #include "logging.h"
 
 #include <config.h>
+#include <glib/gprintf.h>
 #include <glib/gi18n.h>
 
 guint id;

--- a/src/user_signals.c
+++ b/src/user_signals.c
@@ -1,3 +1,4 @@
+#include <glib-unix.h>
 #include <gtk/gtk.h>
 #include "interface.h"
 


### PR DESCRIPTION
Future compilers will not support implicit function declarations by default.  Include <glib/gprintf.h> for a prototype of g_sprintf, and <glib-unix.h> for a prototype of g_unix_signal_add.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
