### PR TITLE
Added option for the ESC character to clear screen and pt_BR translation

### DIFF
--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -1,2 +1,2 @@
-fr hu ru de zh_CN nl_NL
+fr hu ru de zh_CN nl_NL pt_BR
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1,0 +1,760 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-07-20 12:41+0200\n"
+"PO-Revision-Date: 2023-10-31 18:22-0300\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: pt_BR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4\n"
+
+#: ../src/buffer.c:167
+msgid "ERROR : Buffer is not initialized !\n"
+msgstr "ERRO : Buffer não inicializado !\n"
+
+#: ../src/cmdline.c:37
+#, c-format
+msgid ""
+"\n"
+"GTKTerm version %s\n"
+msgstr ""
+"\n"
+"GTKTerm versão %s\n"
+
+#: ../src/cmdline.c:38
+msgid "\t (c) Julien Schmitt\n"
+msgstr "\t (c) Julien Schmitt\n"
+
+#: ../src/cmdline.c:39
+msgid ""
+"\n"
+"This program is released under the terms of the GPL V.2\n"
+msgstr ""
+"\n"
+"Este programa é distribuído sob termos da GPL V.2\n"
+
+#: ../src/cmdline.c:40
+msgid "\t ** Use at your own risks ! **\n"
+msgstr "\t **Use por sua conta e risco ! **\n"
+
+#: ../src/cmdline.c:41
+msgid ""
+"\n"
+"Command line options\n"
+msgstr ""
+"\n"
+"Opções de linha de comando\n"
+
+#: ../src/cmdline.c:42
+msgid "--help or -h : this help screen\n"
+msgstr "--help ou -h : esta tela de ajuda\n"
+
+#: ../src/cmdline.c:43
+msgid "--config <configuration> or -c : load configuration\n"
+msgstr "--config <configuração> ou -c : carrega uma configuração\n"
+
+#: ../src/cmdline.c:44
+msgid "--port <device> or -p : serial port device (default /dev/ttyS0)\n"
+msgstr ""
+"--port <porta> ou -p : dispositivo da porta serial (padrão /dev/ttyS0)\n"
+
+#: ../src/cmdline.c:45
+msgid "--speed <speed> or -s : serial port speed (default 9600)\n"
+msgstr ""
+"--speed <velocidade> ou -s : velocidade da porta serial (padrão 9600)\n"
+
+#: ../src/cmdline.c:46
+msgid "--bits <bits> or -b : number of bits (default 8)\n"
+msgstr "--bits <bits> ou -b : número de bits (padrão 8)\n"
+
+#: ../src/cmdline.c:47
+msgid "--stopbits <stopbits> or -t : number of stopbits (default 1)\n"
+msgstr ""
+"--stopbits <bits_de_parada> ou -t : número de bits de parada (padrão 1)\n"
+
+#: ../src/cmdline.c:48
+msgid "--parity <odd | even> or -a : parity (default none)\n"
+msgstr ""
+"--parity <odd | even> ou -a : paridade (padrão none), pode ser none=nenhuma|"
+"odd=ímpar|even=par\n"
+
+#: ../src/cmdline.c:49
+msgid "--flow <Xon | RTS | RS-485> or -w : flow control (default none)\n"
+msgstr "--flow <Xon | RTS | RS-485> ou -w : controle de fluxo (padrão none)\n"
+
+#: ../src/cmdline.c:50
+msgid "--delay <ms> or -d : end of line delay in ms (default none)\n"
+msgstr ""
+"--delay <ms> ou -d : tempo de espera pelo fim de linha em ms (padrão none)\n"
+
+#: ../src/cmdline.c:51
+msgid ""
+"--char <char> or -r : wait for a special char at end of line (default none)\n"
+msgstr ""
+"--char <caractere> ou -r : esperar por um caractere especial no final da "
+"linha (padrão none)\n"
+
+#: ../src/cmdline.c:52
+msgid "--file <filename> or -f : default file to send (default none)\n"
+msgstr ""
+"--file <nome_do_arquivo> ou -f : arquivo padrão para enviar (padrão none)\n"
+
+#: ../src/cmdline.c:53
+msgid ""
+"--rts_time_before <ms> or -x : for RS-485, time in ms before transmit with "
+"rts on\n"
+msgstr ""
+"--rts_time_before <ms> ou -x : para RS-485, tempo em ms antes de transmitir "
+"com RTS 'on'\n"
+
+#: ../src/cmdline.c:54
+msgid ""
+"--rts_time_after <ms> or -y : for RS-485, time in ms after transmit with rts "
+"on\n"
+msgstr ""
+"--rts_time_after <ms> ou -y : para RS-485, tempo em ms depois de transmitir "
+"com RTS 'on'\n"
+
+#: ../src/cmdline.c:55
+msgid "--echo or -e : switch on local echo\n"
+msgstr "--echo ou -e : ativa eco local\n"
+
+#: ../src/cmdline.c:56
+msgid ""
+"--disable-port-lock or -L: does not lock serial port. Allows to send to "
+"serial port from different terminals\n"
+msgstr ""
+"--disable-port-lock ou -L: não trava a porta. Será permitido a outros "
+"programas enviarem dados para a porta serial\n"
+
+#: ../src/cmdline.c:57
+msgid ""
+"                      Note: incoming data are displayed randomly on only one "
+"terminal\n"
+msgstr ""
+"                      Nota: os dados recebidos serão exibidos aleatoriamente "
+"em apenas um terminal\n"
+
+#: ../src/cmdline.c:167
+msgid "Undefined command line option\n"
+msgstr "Opção de linha de comando não definida\n"
+
+#: ../src/files.c:77
+msgid "Send RAW File"
+msgstr "Enviar arquivo RAW"
+
+#: ../src/files.c:96
+#, c-format
+msgid "Error opening file\n"
+msgstr "Erro abrindo o arquivo\n"
+
+#: ../src/files.c:110
+#, c-format
+msgid "%s : transfer in progress..."
+msgstr "%s : transferência em processo..."
+
+#: ../src/files.c:128
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: ../src/files.c:143
+#, c-format
+msgid "Cannot read file %s: %s\n"
+msgstr "Não foi possível ler o arquivo %s: %s\n"
+
+#: ../src/files.c:178
+#, c-format
+msgid "Error sending file\n"
+msgstr "Erro enviando o arquivo\n"
+
+#: ../src/files.c:206
+#, c-format
+msgid "Error sending file: %s\n"
+msgstr "Erro enviando o arquivo: %s\n"
+
+#: ../src/files.c:292
+msgid "Save RAW File"
+msgstr "Salvar o arquivo RAW"
+
+#: ../src/files.c:311
+#, c-format
+msgid "File error\n"
+msgstr "Arquivo com erro\n"
+
+#: ../src/files.c:322 ../src/logging.c:68 ../src/logging.c:123
+#, c-format
+msgid "Cannot open file %s: %s\n"
+msgstr "Não foi possível abrir o arquivo %s: %s\n"
+
+#. Toplevel
+#: ../src/interface.c:145
+msgid "_File"
+msgstr "_Arquivo"
+
+#: ../src/interface.c:146
+msgid "_Edit"
+msgstr "_Editar"
+
+#: ../src/interface.c:147
+msgid "_Log"
+msgstr "_Log"
+
+#: ../src/interface.c:148
+msgid "_Configuration"
+msgstr "_Configuração"
+
+#: ../src/interface.c:149
+msgid "Control _signals"
+msgstr "_Sinais de controle"
+
+#: ../src/interface.c:150
+msgid "_View"
+msgstr "_Ver"
+
+#: ../src/interface.c:151
+msgid "Hexadecimal _chars"
+msgstr "_Caracteres hexadecimais"
+
+#: ../src/interface.c:152
+msgid "_Help"
+msgstr "A_juda"
+
+#: ../src/interface.c:156
+msgid "_Clear screen"
+msgstr "Apagar a _tela"
+
+#: ../src/interface.c:157
+msgid "_Clear scrollback"
+msgstr "A_pagar a rolagem"
+
+#: ../src/interface.c:158
+msgid "Send _RAW file"
+msgstr "Enviar arquivo _RAW"
+
+#: ../src/interface.c:159
+msgid "_Save RAW file"
+msgstr "_Salvar arquivo RAW"
+
+#. Log Menu
+#: ../src/interface.c:167
+msgid "To file..."
+msgstr "Para o arquivo..."
+
+#. Confuguration Menu
+#: ../src/interface.c:173
+msgid "_Port"
+msgstr "_Porta"
+
+#: ../src/interface.c:174
+msgid "_Main window"
+msgstr "_Janela principal"
+
+#: ../src/interface.c:175
+msgid "_Macros"
+msgstr "_Macros"
+
+#: ../src/interface.c:176
+msgid "_Load configuration"
+msgstr "Carregar con_figuração"
+
+#: ../src/interface.c:177
+msgid "_Save configuration"
+msgstr "_Salvar configuração"
+
+#: ../src/interface.c:178
+msgid "_Delete configuration"
+msgstr "_Deletar configuração"
+
+#. Signals Menu
+#: ../src/interface.c:181
+msgid "Send break"
+msgstr "Enviar break"
+
+#: ../src/interface.c:182
+msgid "_Open Port"
+msgstr "_Abrir a porta"
+
+#: ../src/interface.c:183
+msgid "_Close Port"
+msgstr "_Fechar a porta"
+
+#: ../src/interface.c:184
+msgid "Toggle DTR"
+msgstr "Alternar DTR"
+
+#: ../src/interface.c:185
+msgid "Toggle RTS"
+msgstr "Alternar RTS"
+
+#. Configuration Menu
+#: ../src/interface.c:194
+msgid "Local _echo"
+msgstr "_Eco local"
+
+#: ../src/interface.c:195
+msgid "_CR LF auto"
+msgstr "_CR LF automático"
+
+#: ../src/interface.c:196
+msgid "Timestamp"
+msgstr "Timestamp"
+
+#. View Menu
+#: ../src/interface.c:199
+msgid "Show _index"
+msgstr "Mostrar _índice"
+
+#: ../src/interface.c:200
+msgid "_Send hexadecimal data"
+msgstr "_Enviar dados hexadecimais"
+
+#: ../src/interface.c:205
+msgid "_ASCII"
+msgstr "_ASCII"
+
+#: ../src/interface.c:206
+msgid "_Hexadecimal"
+msgstr "_Hexadecimal"
+
+#: ../src/interface.c:422
+msgid "Resume"
+msgstr "Retomar"
+
+#: ../src/interface.c:567
+msgid "Hexadecimal data to send (separator : ';' or space) : "
+msgstr "Dados hexadecimais para enviar (separador : ';' ou espaço) : "
+
+#: ../src/interface.c:727
+msgid ""
+"GTKTerm is a simple GTK+ terminal used to communicate with the serial port."
+msgstr ""
+"GTKTerm é um terminal em GTK+ fácil de usar para se comunicar com a porta "
+"serial."
+
+#: ../src/interface.c:779
+msgid "Break signal sent!"
+msgstr "Sinal break enviado!"
+
+#: ../src/interface.c:885
+#, c-format
+msgid "0 byte(s) sent!"
+msgstr "0 byte(s) enviados!"
+
+#: ../src/interface.c:899
+msgid "Improper formatted hex input, 0 bytes sent!"
+msgstr "Dados hexadecimais formatados impropriamente, 0 bytes enviados!"
+
+#: ../src/interface.c:910
+#, c-format
+msgid "%d byte(s) sent!"
+msgstr "%d byte(s) enviado(s)!"
+
+#: ../src/logging.c:49
+#, c-format
+msgid "Filename error\n"
+msgstr "Erro no nome do arquivo\n"
+
+#: ../src/logging.c:88
+msgid "Log file selection"
+msgstr "Seleção do arquivo de log"
+
+#: ../src/logging.c:184
+msgid "Failed to log data\n"
+msgstr "Falhou ao registrar dados no log\n"
+
+#: ../src/macros.c:144
+#, c-format
+msgid "Macro \"%s\" sent !"
+msgstr "Macro \"%s\" enviada!"
+
+#: ../src/macros.c:275
+msgid "Shortcut"
+msgstr "Atalho"
+
+#: ../src/macros.c:432
+msgid ""
+"The \"action\" field of a macro is the data to be sent on the port. Text can "
+"be entered, but also special chars, like \\n, \\t, \\r, etc. You can also "
+"enter hexadecimal data preceded by a '\\'. The hexadecimal data should not "
+"begin with a letter (eg. use \\0FF and not \\FF)\n"
+"Examples :\n"
+"\t\"Hello\\n\" sends \"Hello\" followed by a Line Feed\n"
+"\t\"Hello\\0A\" does the same thing but the LF is entered in hexadecimal"
+msgstr ""
+"O campo \"ação\" da macro é o dado a ser enviado na porta. Pode ser texto e "
+"também caracteres especiais, como \\n, \\t, \\r, etc. Você também pode "
+"entrar com dados hexadecimais precedido por uma '\\'. Os dados hexadecimais "
+"não devem iniciar como uma letra (ex. use \\0FF e não \\FF)\n"
+"Exemplos :\n"
+"\t\"Olá\\n\" envia \"Olá\" seguido de uma quebra de linha\n"
+"\t\"Olá\\0A\" faz a mesma coisa, mas a quebra de linha está em hexadecimal"
+
+#: ../src/macros.c:452
+msgid "Configure Macros"
+msgstr "Configurar Macros"
+
+#: ../src/macros.c:489
+msgid "_Add"
+msgstr "_Adicionar"
+
+#: ../src/macros.c:493
+msgid "_Delete"
+msgstr "_Deletar"
+
+#: ../src/macros.c:497
+msgid "_Capture Shortcut"
+msgstr "_Capturar atalho"
+
+#: ../src/parsecfg.c:355
+#, c-format
+msgid "Cannot open configuration file `%s'.\n"
+msgstr "Não foi possível abrir o arquivo de configuração `%s'.\n"
+
+#: ../src/parsecfg.c:358
+#, c-format
+msgid "Cannot create configuration file `%s'.\n"
+msgstr "Não foi possível criar o arquivo de configuração `%s'.\n"
+
+#: ../src/parsecfg.c:361
+#, c-format
+msgid ""
+"%s(%d): %s\n"
+"Syntax error\n"
+msgstr ""
+"%s(%d): %s\n"
+"Erro de sintaxe\n"
+
+#: ../src/parsecfg.c:364
+#, c-format
+msgid ""
+"%s(%d): %s\n"
+"Unrecognized parameter\n"
+msgstr ""
+"%s(%d): %s\n"
+"Parâmetro não reconhecido\n"
+
+#: ../src/parsecfg.c:367
+#, c-format
+msgid ""
+"%s(%d): %s\n"
+"Internal error\n"
+msgstr ""
+"%s(%d): %s\n"
+"Erro interno\n"
+
+#: ../src/parsecfg.c:370
+#, c-format
+msgid ""
+"%s(%d): %s\n"
+"Invalid number\n"
+msgstr ""
+"%s(%d): %s\n"
+"Número inválido\n"
+
+#: ../src/parsecfg.c:373
+#, c-format
+msgid ""
+"%s(%d): %s\n"
+"Out of range\n"
+msgstr ""
+"%s(%d): %s\n"
+"Valor fora da faixa permitida\n"
+
+#: ../src/parsecfg.c:376
+#, c-format
+msgid ""
+"%s(%d): %s\n"
+"Cannot allocate memory.\n"
+msgstr ""
+"%s(%d): %s\n"
+"Não foi possível alocar memória.\n"
+
+#: ../src/parsecfg.c:379
+#, c-format
+msgid ""
+"%s(%d): %s\n"
+"It must be specified TRUE or FALSE.\n"
+msgstr ""
+"%s(%d): %s\n"
+"É preciso especificar TRUE ou FALSE.\n"
+
+#: ../src/parsecfg.c:382
+#, c-format
+msgid ""
+"%s(%d): %s\n"
+"The section name is already used.\n"
+msgstr ""
+"%s(%d): %s\n"
+"O nome da seção já está em uso.\n"
+
+#: ../src/parsecfg.c:385
+#, c-format
+msgid ""
+"%s(%d)\n"
+"There is no closing bracket.\n"
+msgstr ""
+"%s(%d)\n"
+"Colchete não fechado.\n"
+
+#: ../src/parsecfg.c:390
+#, c-format
+msgid ""
+"%s(%d): %s\n"
+"Unexplained error\n"
+msgstr ""
+"%s(%d): %s\n"
+"Erro não catalogado\n"
+
+#: ../src/serial.c:154
+#, c-format
+msgid "Cannot open %s: %s\n"
+msgstr "Não foi possível abrir %s: %s\n"
+
+#: ../src/serial.c:167
+#, c-format
+msgid ""
+"Cannot lock port! The serial port may currently be in use by another "
+"program.\n"
+msgstr ""
+"Não foi possível capturar a porta! A porta serial pode estar atualmente em "
+"uso por outro programa.\n"
+
+#: ../src/serial.c:235
+#, c-format
+msgid "Arbitrary baud rates not supported"
+msgstr "Valores de taxas de transmissão arbitrárias não suportado"
+
+#: ../src/serial.c:352 ../src/serial.c:398
+msgid "Control signals read"
+msgstr "Sinais de controle lidos"
+
+#: ../src/serial.c:364
+msgid "DTR write"
+msgstr "DTR escrito"
+
+#: ../src/serial.c:374
+msgid "RTS write"
+msgstr "RTS escrito"
+
+#: ../src/serial.c:452
+msgid "No open port"
+msgstr "Porta não aberta"
+
+#: ../src/term_config.c:193
+msgid ""
+"No serial devices found!\n"
+"\n"
+"Searched the following paths:\n"
+"\t/dev/ttyS*\n"
+"\t/dev/tts/*\n"
+"\t/dev/ttyUSB*\n"
+"\t/dev/usb/tts/*\n"
+"\n"
+"Enter a different device path in the 'Port' box.\n"
+msgstr ""
+"Não encontrados dispositivos seriais!\n"
+"\n"
+"Procure os seguintes caminhos:\n"
+"\t/dev/ttyS*\n"
+"\t/dev/tts/*\n"
+"\t/dev/ttyUSB*\n"
+"\t/dev/usb/tts/*\n"
+"\n"
+"Entre com um caminho diferente no campo 'Porta'.\n"
+
+#: ../src/term_config.c:202
+msgid "Configuration"
+msgstr "Configuração"
+
+#: ../src/term_config.c:206
+msgid "Serial port"
+msgstr "Porta serial"
+
+#: ../src/term_config.c:212
+msgid "Port:"
+msgstr "Porta:"
+
+#: ../src/term_config.c:214
+msgid "Baud Rate:"
+msgstr "Taxa de transmissão:"
+
+#: ../src/term_config.c:216
+msgid "Parity:"
+msgstr "Paridade:"
+
+#: ../src/term_config.c:362
+msgid "Bits:"
+msgstr "Bits:"
+
+#: ../src/term_config.c:364
+msgid "Stopbits:"
+msgstr "Bits de parada:"
+
+#: ../src/term_config.c:366
+msgid "Flow control:"
+msgstr "Controle de fluxo:"
+
+#. create an expander widget to hide the 'Advanced features'
+#: ../src/term_config.c:417
+msgid "Advanced Configuration Options"
+msgstr "Opções avançadas de configuração"
+
+#: ../src/term_config.c:422
+msgid "ASCII file transfer"
+msgstr "Transferência de arquivo ASCII"
+
+#: ../src/term_config.c:428
+msgid "End of line delay (milliseconds):"
+msgstr "Tempo de espera do fim de linha (milissegundos):"
+
+#: ../src/term_config.c:444
+msgid "Wait for this special character before passing to next line:"
+msgstr "Esperar por estes caracteres antes de passar para a nova linha:"
+
+#: ../src/term_config.c:457
+msgid "RS-485 half-duplex parameters (RTS signal used to send)"
+msgstr "Parâmetros RS-485 half-duplex  (sinal RTS usado para enviar)"
+
+#: ../src/term_config.c:464
+msgid "Time with RTS 'on' before transmit (milliseconds):"
+msgstr "Tempo com RTS em 'on' antes de transmitir (milissegundos):"
+
+#: ../src/term_config.c:466
+msgid "Time with RTS 'on' after transmit (milliseconds):"
+msgstr "Tempo com RTS em 'on' depois de transmitir (milissegundos):"
+
+#: ../src/term_config.c:591
+msgid "Load configuration"
+msgstr "Carregar configuração"
+
+#: ../src/term_config.c:601
+msgid "Delete configuration"
+msgstr "Deletar configuração"
+
+#: ../src/term_config.c:631 ../src/term_config.c:896
+msgid ""
+"Cannot read configuration file!\n"
+"Config file may contain invalid parameter.\n"
+msgstr ""
+"Não foi possível ler o arquivo de configuração!\n"
+"O arquivo de configuração pode conter parâmetros inválidos.\n"
+
+#: ../src/term_config.c:637
+msgid "Configurations"
+msgstr "Configurações"
+
+#: ../src/term_config.c:704
+msgid "Save configuration"
+msgstr "Salvar configuração"
+
+#: ../src/term_config.c:716
+msgid "Configuration name: "
+msgstr "Nome da configuração: "
+
+#: ../src/term_config.c:750
+msgid ""
+"Cannot save configuration file!\n"
+"Config file may contain invalid parameter.\n"
+msgstr ""
+"Não foi possível salvar o arquivo de configuração!\n"
+"O arquivo de configuração pode conter parâmetros inválidos.\n"
+
+#: ../src/term_config.c:770
+msgid "Cannot overwrite section!"
+msgstr "Não foi possível sobrescrever a seção!"
+
+#: ../src/term_config.c:775
+msgid "Cannot read configuration file!"
+msgstr "Não foi possível ler o arquivo de configuração!"
+
+#: ../src/term_config.c:785
+#, c-format
+msgid "Configuration [%s] saved\n"
+msgstr "Configuração [%s] salva\n"
+
+#: ../src/term_config.c:804
+msgid ""
+"Cannot write configuration file!\n"
+"Config file may contain invalid parameter.\n"
+msgstr ""
+"Não foi possível escrever no arquivo de configuração!\n"
+"O arquivo de configuração pode conter parâmetros inválidos.\n"
+
+#: ../src/term_config.c:819
+#, c-format
+msgid ""
+"<b>Section [%s] already exists.</b>\n"
+"\n"
+"Do you want to overwrite it ?"
+msgstr ""
+"<b>Seção [%s] já existe.</b>\n"
+"\n"
+"Você gostaria de sobrescrevê-la?"
+
+#: ../src/term_config.c:879
+msgid "Cannot delete section!"
+msgstr "Não foi possível deletar a seção!"
+
+#: ../src/term_config.c:1060
+#, c-format
+msgid "No section \"%s\" in configuration file\n"
+msgstr "A seção \"%s\" não foi encontrada no arquivo de configuração\n"
+
+#: ../src/term_config.c:1105
+#, c-format
+msgid "Baudrate %d may not be supported by all hardware"
+msgstr "A taxa de transmissão %d pode não ser suportada por todos os hardwares"
+
+#: ../src/term_config.c:1112
+#, c-format
+msgid ""
+"Invalid number of stop-bits: %d\n"
+"Falling back to default number of stop-bits number: %d\n"
+msgstr ""
+"Número de bits de parada inválido: %d\n"
+"Voltando para o número de bits de parada padrão: %d\n"
+
+#: ../src/term_config.c:1120
+#, c-format
+msgid ""
+"Invalid number of bits: %d\n"
+"Falling back to default number of bits: %d\n"
+msgstr ""
+"Número de bits inválido: %d\n"
+"Voltando para o número de bits padrão: %d\n"
+
+#: ../src/term_config.c:1128
+#, c-format
+msgid ""
+"Invalid delay: %d ms\n"
+"Falling back to default delay: %d ms\n"
+msgstr ""
+"Tempo de espera inválida: %d ms\n"
+"Voltando para o tempo de espera padrão: %d ms\n"
+
+#: ../src/term_config.c:1158
+#, c-format
+msgid ""
+"Configuration file (%s) with\n"
+"[default] configuration has been created.\n"
+msgstr ""
+"Arquivo de configuração com (%s)\n"
+"[padrão] configuração foi criada.\n"
+
+#: ../src/term_config.c:1414
+#, c-format
+msgid "Cannot find section %s\n"
+msgstr "Não foi possível encontrar a seção %s\n"
+
+#: ../src/term_config.c:1454
+msgid "Main Window"
+msgstr "Janela principal"

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -86,7 +86,7 @@ unsigned int insert_timestamp(char *buffer)
   return size;
 }
 
-void put_chars(const char *chars, unsigned int size, gboolean crlf_auto)
+void put_chars(const char *chars, unsigned int size, gboolean crlf_auto, gboolean esc_clear_screen)
 {
 	// buffer must still be valid after cr conversion or adding timestamp
 	// only pointer is copied below
@@ -94,13 +94,18 @@ void put_chars(const char *chars, unsigned int size, gboolean crlf_auto)
 	const char *characters;
 
 	/* If the auto CR LF mode on, read the buffer to add \r before \n */
-	if(crlf_auto || timestamp_on)
+	if(crlf_auto || timestamp_on || esc_clear_screen)
 	{
 		int i, out_size = 0;
 
 		for (i=0; i<size; i++)
 		{
-      if(crlf_auto)
+			if(esc_clear_screen && chars[i] == '\x1b')
+			{
+				clear_buffer();
+				continue;
+			}
+			if(crlf_auto)
 			{
 				if (chars[i] == '\r')
 				{
@@ -160,7 +165,7 @@ void put_chars(const char *chars, unsigned int size, gboolean crlf_auto)
 		// converted newline characters
 		chars = out_buffer;
 		size = out_size;
-	} // if(crlf_auto || timestamp_on)
+	} // if(crlf_auto || timestamp_on || esc_clear_screen)
 
 	if(buffer == NULL)
 	{

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -23,7 +23,7 @@
 
 void create_buffer(void);
 void delete_buffer(void);
-void put_chars(const char *, unsigned int, gboolean);
+void put_chars(const char *, unsigned int, gboolean, gboolean);
 void clear_buffer(void);
 void write_buffer(void);
 void set_display_func(void (*func)(const char *, unsigned int));

--- a/src/interface.c
+++ b/src/interface.c
@@ -85,6 +85,7 @@
 guint id;
 gboolean echo_on;
 gboolean crlfauto_on;
+gboolean esc_clear_screen_on;
 gboolean timestamp_on = 0;
 GtkWidget *StatusBar;
 GtkWidget *signals[6];
@@ -122,6 +123,7 @@ gboolean Envoie_car(GtkWidget *, GdkEventKey *, gpointer);
 gboolean control_signals_read(void);
 void echo_toggled_callback(GtkAction *action, gpointer data);
 void CR_LF_auto_toggled_callback(GtkAction *action, gpointer data);
+void esc_clear_screen_toggled_callback(GtkAction *action, gpointer data);
 void timestamp_toggled_callback(GtkAction *action, gpointer data);
 void view_radio_callback(GtkAction *action, gpointer data);
 void view_hexadecimal_chars_radio_callback(GtkAction* action, gpointer data);
@@ -194,6 +196,7 @@ const GtkToggleActionEntry menu_toggle_entries[] =
 	/* Configuration Menu */
 	{"LocalEcho", NULL, N_("Local _echo"), NULL, NULL, G_CALLBACK(echo_toggled_callback), FALSE},
 	{"CRLFauto", NULL, N_("_CR LF auto"), NULL, NULL, G_CALLBACK(CR_LF_auto_toggled_callback), FALSE},
+	{"EscClearScreen", NULL, N_("ESC clear scree_n"), NULL, NULL, G_CALLBACK(esc_clear_screen_toggled_callback), FALSE},
 	{"Timestamp", NULL, N_("Timestamp"), NULL, NULL, G_CALLBACK(timestamp_toggled_callback), FALSE},
 
 	/* View Menu */
@@ -245,6 +248,7 @@ static const char *ui_description =
     "      <menuitem action='ConfigTerminal'/>"
     "      <menuitem action='LocalEcho'/>"
     "      <menuitem action='CRLFauto'/>"
+    "      <menuitem action='EscClearScreen'/>"
     "      <menuitem action='Timestamp'/>"
     "      <menuitem action='Macros'/>"
     "      <separator/>"
@@ -390,6 +394,23 @@ void CR_LF_auto_toggled_callback(GtkAction *action, gpointer data)
 {
 	crlfauto_on = gtk_toggle_action_get_active (GTK_TOGGLE_ACTION(action));
 	configure_crlfauto(crlfauto_on);
+}
+
+void Set_esc_clear_screen(gboolean esc_clear_screen)
+{
+	GtkAction *action;
+
+	esc_clear_screen_on = esc_clear_screen;
+
+	action = gtk_action_group_get_action(action_group, "EscClearScreen");
+	if(action)
+		gtk_toggle_action_set_active(GTK_TOGGLE_ACTION(action), esc_clear_screen_on);
+}
+
+void esc_clear_screen_toggled_callback(GtkAction *action, gpointer data)
+{
+	esc_clear_screen_on = gtk_toggle_action_get_active (GTK_TOGGLE_ACTION(action));
+	configure_esc_clear_screen(esc_clear_screen_on);
 }
 
 void Set_timestamp(gboolean timestamp)
@@ -705,7 +726,7 @@ gint send_serial(gchar *string, gint len)
 	if(bytes_written > 0)
 	{
 		if(echo_on)
-			put_chars(string, bytes_written, crlfauto_on);
+			put_chars(string, bytes_written, crlfauto_on, esc_clear_screen_on);
 	}
 
 	return bytes_written;

--- a/src/interface.h
+++ b/src/interface.h
@@ -30,6 +30,7 @@ void show_message(gchar *, gint);
 void clear_display(void);
 void set_view(guint);
 void Set_crlfauto(gboolean crlfauto);
+void Set_esc_clear_screen(gboolean esc_clear_screen);
 void Set_timestamp(gboolean timestamp);
 gint send_serial(gchar *, gint);
 void Put_temp_message(const gchar *, gint);

--- a/src/serial.c
+++ b/src/serial.c
@@ -71,7 +71,7 @@ gboolean Lis_port(GIOChannel* src, GIOCondition cond, gpointer data)
 		bytes_read = read(serial_port_fd, c, BUFFER_RECEPTION);
 		if(bytes_read > 0)
 		{
-			put_chars(c, bytes_read, config.crlfauto);
+			put_chars(c, bytes_read, config.crlfauto, config.esc_clear_screen);
 
 			if(config.car != -1 && waiting_for_char == TRUE)
 			{
@@ -319,6 +319,11 @@ void configure_echo(gboolean echo)
 void configure_crlfauto(gboolean crlfauto)
 {
 	config.crlfauto = crlfauto;
+}
+
+void configure_esc_clear_screen(gboolean esc_clear_screen)
+{
+	config.esc_clear_screen = esc_clear_screen;
 }
 
 void Close_port(void)

--- a/src/serial.h
+++ b/src/serial.h
@@ -24,6 +24,7 @@ int lis_sig(void);
 void Close_port(void);
 void configure_echo(gboolean);
 void configure_crlfauto(gboolean);
+void configure_esc_clear_screen(gboolean);
 void sendbreak(void);
 gint set_custom_speed(int, int);
 gchar* get_port_string(void);

--- a/src/term_config.c
+++ b/src/term_config.c
@@ -78,6 +78,7 @@ gint *rts_time_before_tx;
 gint *rts_time_after_tx;
 gint *echo;
 gint *crlfauto;
+gint *esc_clear_screen;
 gint *timestamp;
 cfgList **macro_list = NULL;
 gchar **font;
@@ -111,6 +112,7 @@ cfgStruct cfg[] =
 	{"rs485_rts_time_after_tx", CFG_INT, &rts_time_after_tx},
 	{"echo", CFG_BOOL, &echo},
 	{"crlfauto", CFG_BOOL, &crlfauto},
+	{"esc_clear_screen", CFG_BOOL, &esc_clear_screen},
 	{"timestamp", CFG_BOOL, &timestamp},
 	{"font", CFG_STRING, &font},
 	{"macros", CFG_STRING_LIST, &macro_list},
@@ -176,6 +178,7 @@ void config_file_init(void)
 void ConfigFlags(void)
 {
 	Set_crlfauto(config.crlfauto);
+	Set_esc_clear_screen(config.esc_clear_screen);
 	Set_timestamp(config.timestamp);
 }
 
@@ -973,6 +976,11 @@ gint Load_configuration_from_file(gchar *config_name)
 				else
 					config.crlfauto = FALSE;
 
+				if(esc_clear_screen[i] != -1)
+					config.esc_clear_screen = (gboolean)esc_clear_screen[i];
+				else
+					config.esc_clear_screen = FALSE;
+
 				if(timestamp[i] != -1)
 					config.timestamp = (gboolean)timestamp[i];
 				else
@@ -1199,6 +1207,7 @@ void Hard_default_configuration(void)
 	config.car = DEFAULT_CHAR;
 	config.echo = DEFAULT_ECHO;
 	config.crlfauto = FALSE;
+	config.esc_clear_screen = FALSE;
 	config.timestamp = FALSE;
   config.disable_port_lock = FALSE;
 
@@ -1303,6 +1312,14 @@ void Copy_configuration(int pos)
 		string = g_strdup_printf("True");
 
 	cfgStoreValue(cfg, "crlfauto", string, CFG_INI, pos);
+	g_free(string);
+
+	if(config.esc_clear_screen == FALSE)
+		string = g_strdup_printf("False");
+	else
+		string = g_strdup_printf("True");
+
+	cfgStoreValue(cfg, "esc_clear_screen", string, CFG_INI, pos);
 	g_free(string);
 
 	if(config.timestamp == FALSE)

--- a/src/term_config.h
+++ b/src/term_config.h
@@ -47,6 +47,7 @@ struct configuration_port
 	gchar car;                   // caractere attendre
 	gboolean echo;               // echo local
 	gboolean crlfauto;           // line feed auto
+	gboolean esc_clear_screen;   // clear screen when receive ESC char ('\x1b' - 27)
 	gboolean timestamp;
 	gboolean disable_port_lock;
 };


### PR DESCRIPTION
Hi!

It was added option for the ESC character to clear screen, as well as "CR LF auto". Also pt_BR translation.

I tested on Debian Trixie (testing/13), all packages updated and pt_BR localized, replacing the gtkterm package with this one, compiled and packaging with:
```
# in the same directory where gtkterm was cloned
mkdir deb
cd deb

# make sure deb-src is enabled in /etc/apt/sources.list
apt source gtkterm  
cd gtkterm-1.2.?/

# root instalation
sudo apt-get install quilt
sudo apt-get build-dep gtkterm
sudo apt-get install devscripts

export QUILT_PATCHES=debian/patches
quilt new 99_esc_clear_screen.patch
quilt add src/buffer.c src/buffer.h src/interface.c src/interface.h \
          src/serial.c src/serial.h src/term_config.c src/term_config.h \
          src/user_signals.c po/LINGUAS po/pt_BR.po

cp -auv ../../gtkterm/src/* src/
cp -auv ../../gtkterm/po/*.po ../../gtkterm/po/LINGUAS po/

quilt refresh

export EMAIL=your@email  # replace your@email with yours
dch -i "Added functionality to the ESC character ('\\x1b' - 27) to clear the screen"
dpkg-source --commit
debuild -uc -us

cd ..
sudo dpkg -i gtkterm_1.2.?-*.deb # root instalation
#or
# cp -v gtkterm_1.2.?-*.deb /tmp; su - -c "dpkg -i /tmp/gtkterm_1.2.?-*.deb"
```